### PR TITLE
redoc-cli requires absolute path to index.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,14 @@ docker run --rm -v "${PWD}:/local" openapitools/openapi-generator-cli validate -
 ```
 
 ## Building Redoc single page html documentation
+
 Edit **rt.yml** - remove **components.schemas.ResultItem.discriminator** node
+
 Edit **rt-authenticity.yml** - remove **components.schemas.AuthenticityCheckResultItem.discriminator**
-Than run next command:
+
+Then run next command:
 ```
-npx redoc-cli bundle index.yml --output document-reader-static-doc.html \
+npx redoc-cli bundle "$PWD/index.yml" --output document-reader-static-doc.html \
 --options.maxDisplayedEnumValues=5 --options.theme.logo.gutter="20px" \
 --options.theme.colors.primary.main="#8a53cb" --options.expandResponses="all" \
 --options.expandSingleSchemaField --options.hideDownloadButton --options.jsonSampleExpandLevel="6"


### PR DESCRIPTION
`redoc-cli` requires an absolute path to `index.yml` for some reason. If you use `index.yml` or `./index.yml` it complains that `/index.yml` does not exist.
Also fixed some formatting and a typo.