### PR TITLE
chore: migrate to reusable workflows

### DIFF
--- a/.github/workflows/back-merge.yaml
+++ b/.github/workflows/back-merge.yaml
@@ -1,0 +1,16 @@
+name: Back Merge
+
+on:
+  push:
+    branches:
+      - master
+      - stable
+
+jobs:
+  back-merge:
+    uses: regulaforensics/reusable-workflows/.github/workflows/back-merge.yaml@f9848fa9ec1ae1e6285b56200ac1f24fbfaee0c3 # main
+    with:
+      source_branch: ${{ github.ref_name }}
+      merge_pairs: "master:stable,stable:develop"
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sast.yaml
+++ b/.github/workflows/sast.yaml
@@ -1,0 +1,47 @@
+# This repository is public and cannot call reusable workflows from a private
+# repository (regulaforensics/reusable-workflows). The logic below is a local
+# copy that mirrors the reusable workflow exactly. SHA pins are kept up-to-date
+# by Renovate (see renovate.json).
+name: SAST
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - staging
+      - production
+      - stable
+      - main
+      - master
+
+jobs:
+  semgrep:
+    name: semgrep-oss/scan
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep@sha256:bdf7013b2c3634a487671158da77c554f531742326b543a9464d2adf6c433ac8
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Scan
+        shell: bash
+        env:
+          # Exclude existing .github/workflows/*.yml — they use mutable action tags.
+          # Pinning those files is tracked separately.
+          EXCLUDE_PATHS: '.github/workflows'
+          EXCLUDE_RULES: ''
+        run: |
+          EXCLUDED_PATHS=()
+          if [[ -n "$EXCLUDE_PATHS" ]]; then
+            for path in $EXCLUDE_PATHS; do
+              EXCLUDED_PATHS+=("--exclude" "$path")
+            done
+          fi
+
+          EXCLUDED_RULES=()
+          if [[ -n "$EXCLUDE_RULES" ]]; then
+            for rule in $EXCLUDE_RULES; do
+              EXCLUDED_RULES+=("--exclude-rule" "$rule")
+            done
+          fi
+
+          semgrep scan --config auto "${EXCLUDED_PATHS[@]}" "${EXCLUDED_RULES[@]}" --error --verbose

--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -1,0 +1,32 @@
+# This repository is public and cannot call reusable workflows from a private
+# repository (regulaforensics/reusable-workflows). The logic below is a local
+# copy that mirrors the reusable workflow exactly. SHA pins are kept up-to-date
+# by Renovate (see renovate.json).
+name: Trivy Scan
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - staging
+      - production
+      - stable
+      - main
+      - master
+
+jobs:
+  trivy-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Run Trivy scanner
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: 'fs'
+          exit-code: '1'
+          ignore-unfixed: true
+          severity: 'CRITICAL,HIGH,MEDIUM,LOW'
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2

--- a/.github/workflows/verify-linked-issue.yaml
+++ b/.github/workflows/verify-linked-issue.yaml
@@ -1,0 +1,50 @@
+# This repository is public and cannot call reusable workflows from a private
+# repository (regulaforensics/reusable-workflows). The logic below is a local
+# copy that mirrors the reusable workflow exactly. SHA pins are kept up-to-date
+# by Renovate (see renovate.json).
+name: Verify Issue
+
+on:
+  pull_request:
+    types: [edited, synchronize, opened, reopened]
+
+jobs:
+  verify_linked_issue:
+    runs-on: ubuntu-latest
+    name: PR has a linked issue.
+    steps:
+      - name: Verify Linked Issue
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const skipBranchPattern = '';
+            const issueUrlPattern = 'https://redmine.regulaforensics.com/';
+            const clickupUrlPattern = 'https://app.clickup.com/';
+            const pr = context.payload.pull_request;
+
+            if (skipBranchPattern && pr.head.ref.startsWith(skipBranchPattern)) {
+              console.log(`Skipping verification — branch "${pr.head.ref}" matches skip pattern "${skipBranchPattern}".`);
+              return;
+            }
+
+            if (!pr.body) {
+              console.log("No Linked Issue Found!");
+              core.setFailed('No linked issue found in the pull request description.');
+              return;
+            }
+
+            const hasRedmineIssue = issueUrlPattern && pr.body.includes(issueUrlPattern);
+            const hasClickupIssue = clickupUrlPattern && pr.body.includes(clickupUrlPattern);
+
+            if (!hasRedmineIssue && !hasClickupIssue) {
+              console.log("No Linked Issue Found!");
+              core.setFailed('No linked issue found in the pull request description.');
+              return;
+            }
+
+            if (hasRedmineIssue) {
+              console.log(`Linked issue found matching pattern "${issueUrlPattern}".`);
+            }
+            if (hasClickupIssue) {
+              console.log(`Linked issue found matching pattern "${clickupUrlPattern}".`);
+            }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "enabledManagers": [
+    "github-actions"
+  ],
+  "labels": [
+    "dependencies"
+  ],
+  "prBodyNotes": [
+    "https://redmine.regulaforensics.com/issues/58096"
+  ],
+  "packageRules": [
+    {
+      "description": "Update all GitHub Actions to latest, including major version bumps",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "groupName": "GitHub Actions dependencies",
+      "groupSlug": "github-actions-deps",
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ],
+      "schedule": [
+        "before 6am on wednesday"
+      ],
+      "automerge": false,
+      "enabled": true
+    }
+  ],
+  "github-actions": {
+    "enabled": true,
+    "pinDigests": true
+  }
+}


### PR DESCRIPTION
https://redmine.regulaforensics.com/issues/63091

## Summary

Migrate `DocumentReader-web-openapi` to use standardized security scanning workflows.

> ⚠️ **Public repo restriction**: GitHub does not allow public repositories to call reusable workflows from a private repository. Workflow files below are **local copies** that mirror `regulaforensics/reusable-workflows` exactly, with SHA-pinned actions. Renovate keeps pins up-to-date.

## Changes

- `sast.yaml` — added inline local copy; `exclude_paths: .github/workflows` to suppress findings in existing workflow files with mutable tags; SHA-pinned
- `trivy-scan.yaml` — added inline local copy; SHA-pinned
- `verify-linked-issue.yaml` — added inline local copy; SHA-pinned
- `back-merge.yaml` — replaced old `back-merge-handler.yml` with `reusable-workflows/back-merge.yaml@f9848fa`
- `renovate.json` — updated to canonical template